### PR TITLE
Filter RFC1918 addresses for ipv4NetworkEvent

### DIFF
--- a/rules/execution/5eb2a181-4a04-412b-8389-8102064997dd.ioc
+++ b/rules/execution/5eb2a181-4a04-412b-8389-8102064997dd.ioc
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<OpenIOC xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="5eb2a181-4a04-412b-8389-8102064997dd" last-modified="2021-12-17T16:08:35Z" published-date="0001-01-01T00:00:00" xmlns="http://openioc.org/schemas/OpenIOC_1.1">
+  <metadata>
+    <short_description>LOG4J CVE-2021-44228 POTENTIAL EXPLOITATION NON-RFC1918 (METHODOLOGY)</short_description>
+    <description>CVE-2021-44228 or Log4Shell is a Remote Code Execution vulnerability in Log4J2 versions between 2.0 and 2.14.1, a popular Java logging library. If attackers can control the messages logged by Log4J, they can achieve code execution by sending specially crafted strings that leverage JNDI (Java Naming and Directory Interface) over multiple protocols including LDAP and RMI. On Windows and Linux systems this IOC detects outbound network connections from Java processes over port numbers associated with LDAP, DNS, and RMI. On Window systems, this IOC detects Java processes downloading .class resources via HTTP, a technique observed in the wild. These detections are indicative of successful exploitation. This indicator filters out RFC1918 IP addresses in the Remote IP Address field.</description>
+    <authored_by>FireEye</authored_by>
+    <authored_date>2021-12-12T16:17:11Z</authored_date>
+    <links>
+      <link href="" rel="caveat">Methodology</link>
+    </links>
+  </metadata>
+  <criteria>
+    <Indicator operator="OR" id="c1e2f95e-3c82-4578-be8a-c5333a0a2c2a">
+      <Indicator operator="AND" id="f0761aa3-76ae-4e7f-b1aa-064b52fe85c0">
+        <IndicatorItem id="44407303-63b4-4417-bc0b-6f58548d2b53" condition="starts-with" preserve-case="false" negate="false">
+          <Context document="ipv4NetworkEvent" search="ipv4NetworkEvent/process" type="event" />
+          <Content type="string">java</Content>
+        </IndicatorItem>
+        <IndicatorItem id="40ee0f5a-83db-4b59-9561-eaf2dbdfa0d2" condition="starts-with" preserve-case="false" negate="true">
+          <Context document="eventItem" search="eventItem/ipv4NetworkEvent/remoteIP" type="endpoint" />
+          <Content type="IP">10.</Content>
+        </IndicatorItem>
+        <IndicatorItem id="28abc6cb-fb90-408c-8793-80a62ccf3fd0" condition="matches" preserve-case="false" negate="true">
+          <Context document="eventItem" search="eventItem/ipv4NetworkEvent/remoteIP" type="endpoint" />
+          <Content type="IP">^172\.(1[6-9]|2[0-9]|3[0-1])\.</Content>
+        </IndicatorItem>
+        <IndicatorItem id="61c55c57-5740-4c3c-b01f-335676eb6d7a" condition="starts-with" preserve-case="false" negate="true">
+          <Context document="eventItem" search="eventItem/ipv4NetworkEvent/remoteIP" type="endpoint" />
+          <Content type="IP">192.168.</Content>
+        </IndicatorItem>
+        <Indicator operator="OR" id="ad4524c4-0ddf-49f4-93ce-90ea5dfc4857">
+          <IndicatorItem id="454f68ac-5553-421e-9f6c-f11e29acb3f3" condition="is" preserve-case="false" negate="false">
+            <Context document="ipv4NetworkEvent" search="ipv4NetworkEvent/remotePort" type="event" />
+            <Content type="int">1389</Content>
+          </IndicatorItem>
+          <IndicatorItem id="2ce88560-450e-4ac4-bdf9-c959e4585f5d" condition="is" preserve-case="false" negate="false">
+            <Context document="ipv4NetworkEvent" search="ipv4NetworkEvent/remotePort" type="event" />
+            <Content type="int">389</Content>
+          </IndicatorItem>
+          <IndicatorItem id="2b52b74e-30a8-46dd-8c8e-f89d3ba7a4a1" condition="is" preserve-case="false" negate="false">
+            <Context document="ipv4NetworkEvent" search="ipv4NetworkEvent/remotePort" type="event" />
+            <Content type="int">1099</Content>
+          </IndicatorItem>
+          <IndicatorItem id="a4f985bd-79a6-49b7-af6f-e0110e63ffb5" condition="is" preserve-case="false" negate="false">
+            <Context document="ipv4NetworkEvent" search="ipv4NetworkEvent/remotePort" type="event" />
+            <Content type="int">53</Content>
+          </IndicatorItem>
+          <IndicatorItem id="5fdf2f06-67ba-4ff0-953f-1362cfee3f6e" condition="is" preserve-case="false" negate="false">
+            <Context document="ipv4NetworkEvent" search="ipv4NetworkEvent/remotePort" type="event" />
+            <Content type="int">5353</Content>
+          </IndicatorItem>
+        </Indicator>
+      </Indicator>
+      <Indicator operator="AND" id="2beed0a3-5c15-4f16-b817-289fc82b5cb1">
+        <IndicatorItem id="66fc16ef-16c4-41f6-ab81-ef2af987343a" condition="ends-with" preserve-case="false" negate="false">
+          <Context document="urlMonitorEvent" search="urlMonitorEvent/requestUrl" type="event" />
+          <Content type="string">.class</Content>
+        </IndicatorItem>
+        <IndicatorItem id="6aa3899e-7f8a-490c-9704-7dc5b82852f4" condition="starts-with" preserve-case="false" negate="false">
+          <Context document="urlMonitorEvent" search="urlMonitorEvent/process" type="event" />
+          <Content type="string">java</Content>
+        </IndicatorItem>
+      </Indicator>
+    </Indicator>
+  </criteria>
+  <parameters />
+</OpenIOC>


### PR DESCRIPTION
This PR adds a replica of LOG4J CVE-2021-44228 POTENTIAL EXPLOITATION (METHODOLOGY) with logic to filter out RFC1918 IP addresses.